### PR TITLE
Fix non-printable keys in browser renderer

### DIFF
--- a/packages/web/src/browser-renderer.ts
+++ b/packages/web/src/browser-renderer.ts
@@ -509,7 +509,7 @@ export class BrowserRenderer {
       meta: event.metaKey,
       shift: event.shiftKey,
       option: event.altKey,
-      sequence: event.key,
+      sequence: event.key.length === 1 ? event.key : "",
       number: false,
       raw: event.key,
       eventType: "press" as const,


### PR DESCRIPTION
## Summary
- Fixes the `sequence` field in key event handling to only pass single-character keys, filtering out non-printable keys (e.g., Shift, Control, Alt) by checking `event.key.length === 1`

## Test plan
- [ ] Verify that typing regular characters works as expected
- [ ] Verify that pressing non-printable keys (Shift, Control, Alt, etc.) no longer produces unintended input

🤖 Generated with [Claude Code](https://claude.com/claude-code)