### PR TITLE
Fix page scroll blocked when hovering over terminal demo

### DIFF
--- a/packages/web/src/browser-renderer.ts
+++ b/packages/web/src/browser-renderer.ts
@@ -276,7 +276,6 @@ export class BrowserRenderer {
 
     // --- Scroll events ---
     const onWheel = (e: WheelEvent) => {
-      e.preventDefault()
       const { col, row } = this.pixelToCell(e.clientX, e.clientY)
       const hitId = this.renderContext.hitTest(col, row)
       if (hitId !== null) {
@@ -286,7 +285,7 @@ export class BrowserRenderer {
         }
       }
     }
-    this.canvas.addEventListener("wheel", onWheel, { passive: false })
+    this.canvas.addEventListener("wheel", onWheel)
     this.cleanupListeners.push(() => this.canvas.removeEventListener("wheel", onWheel))
 
     // --- Drag enter/leave for visual feedback ---


### PR DESCRIPTION
## Summary
- The wheel event handler on the canvas was unconditionally calling `e.preventDefault()`, which blocked native page scrolling whenever the mouse was over a gridland canvas (e.g. the terminal demo on the docs site)
- Removed the `preventDefault()` call and switched to a passive wheel listener, so page scroll works normally while TUI scroll events still dispatch to renderables

## Future consideration
If a component needs to own scroll (e.g. a scrollable list or chat window), it should opt in by calling `event.preventDefault()` on the TUI MouseEvent in its scroll handler. The browser-renderer can then check `tuiEvent.defaultPrevented` and conditionally block page scroll. This keeps the default behavior permissive and avoids breaking page scroll for components that don't need it.

## Test plan
- [ ] Open docs site, hover over the terminal demo window, scroll — page should scroll normally
- [ ] Verify any TUI components with scroll handlers (e.g. chat) still receive scroll events

🤖 Generated with [Claude Code](https://claude.com/claude-code)